### PR TITLE
Bugfix/img owner edit delete - Allow only for Owners, else show error

### DIFF
--- a/src/main/resources/templates/images/image.html
+++ b/src/main/resources/templates/images/image.html
@@ -15,15 +15,15 @@
     <div class="dtc v-mid w-75 tr">
         <a th:href="@{/editImage(imageId=${image.id})}">Edit</a>
         <!-- Show the edit error if the non owner of the image is trying to edit the image-->
-        <!--Uncomment the below code to show the error if the non owner of the image is trying to edit the image-->
-        <!--<div th:if="${editError}">Only the owner of the image can edit the image</div>-->
+        <!-- Code to show the error if the non owner of the image is trying to edit the image-->
+        <div th:if="${editError}">Only the owner of the image can edit the image</div>
         <div><br></div>
         <form th:action="@{/deleteImage(imageId=${image.id})}" th:method="delete">
             <input type="submit" value="Delete"/>
         </form>
         <!-- Show the delete error if the non owner of the image is trying to delete the image-->
-        <!--Uncomment the below code to show the error if the non owner of the image is trying to delete the image-->
-        <!--<div th:if="${deleteError}">Only the owner of the image can delete the image</div>-->
+        <!-- Code to show the error if the non owner of the image is trying to delete the image-->
+        <div th:if="${deleteError}">Only the owner of the image can delete the image</div>
     </div>
 </nav>
 


### PR DESCRIPTION
- Merge Fix for allowing only owner for Edit or delete of Image.

- For Non owners, show Error message on the same page.